### PR TITLE
[BE] CAT-109 본인 피드 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/sixmycat/catchy/feature/feed/query/controller/FeedQueryController.java
+++ b/src/main/java/com/sixmycat/catchy/feature/feed/query/controller/FeedQueryController.java
@@ -1,9 +1,12 @@
 package com.sixmycat.catchy.feature.feed.query.controller;
 
 import com.sixmycat.catchy.common.dto.ApiResponse;
+import com.sixmycat.catchy.common.dto.PageResponse;
 import com.sixmycat.catchy.feature.feed.query.dto.response.FeedDetailResponse;
+import com.sixmycat.catchy.feature.feed.query.dto.response.FeedSummaryResponse;
 import com.sixmycat.catchy.feature.feed.query.service.FeedQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,5 +23,15 @@ public class FeedQueryController {
     ) {
         FeedDetailResponse response = feedQueryService.getFeedDetail(feedId, userId);
         return ApiResponse.success(response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<PageResponse<FeedSummaryResponse>>> getMyFeeds(
+            @RequestHeader(value = "X-USER-ID", required = false) Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "12") int size
+    ) {
+        PageResponse<FeedSummaryResponse> result = feedQueryService.getMyFeeds(userId, page, size);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/sixmycat/catchy/feature/feed/query/dto/response/FeedSummaryResponse.java
+++ b/src/main/java/com/sixmycat/catchy/feature/feed/query/dto/response/FeedSummaryResponse.java
@@ -1,0 +1,16 @@
+package com.sixmycat.catchy.feature.feed.query.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FeedSummaryResponse {
+    private Long feedId;
+    private String thumbnailUrl; // 첫 번째 이미지
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/sixmycat/catchy/feature/feed/query/mapper/FeedQueryMapper.java
+++ b/src/main/java/com/sixmycat/catchy/feature/feed/query/mapper/FeedQueryMapper.java
@@ -2,6 +2,7 @@ package com.sixmycat.catchy.feature.feed.query.mapper;
 
 import com.sixmycat.catchy.feature.feed.query.dto.response.FeedBaseInfo;
 import com.sixmycat.catchy.feature.feed.query.dto.response.CommentPreview;
+import com.sixmycat.catchy.feature.feed.query.dto.response.FeedSummaryResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -18,4 +19,6 @@ public interface FeedQueryMapper {
     Optional<CommentPreview> findLatestCommentPreview(@Param("feedId") Long feedId);
 
     boolean isFeedLikedByUser(@Param("feedId") Long feedId, @Param("userId") Long userId);
+
+    List<FeedSummaryResponse> findMyFeeds(Long memberId);
 }

--- a/src/main/java/com/sixmycat/catchy/feature/feed/query/service/FeedQueryService.java
+++ b/src/main/java/com/sixmycat/catchy/feature/feed/query/service/FeedQueryService.java
@@ -1,7 +1,10 @@
 package com.sixmycat.catchy.feature.feed.query.service;
 
+import com.sixmycat.catchy.common.dto.PageResponse;
 import com.sixmycat.catchy.feature.feed.query.dto.response.FeedDetailResponse;
+import com.sixmycat.catchy.feature.feed.query.dto.response.FeedSummaryResponse;
 
 public interface FeedQueryService {
     FeedDetailResponse getFeedDetail(Long feedId, Long userId);
+    PageResponse<FeedSummaryResponse> getMyFeeds(Long memberId, int page, int size);
 }

--- a/src/main/java/com/sixmycat/catchy/feature/feed/query/service/FeedQueryServiceImpl.java
+++ b/src/main/java/com/sixmycat/catchy/feature/feed/query/service/FeedQueryServiceImpl.java
@@ -1,11 +1,11 @@
 package com.sixmycat.catchy.feature.feed.query.service;
 
+import com.github.pagehelper.PageHelper;
+import com.github.pagehelper.PageInfo;
+import com.sixmycat.catchy.common.dto.PageResponse;
 import com.sixmycat.catchy.exception.BusinessException;
 import com.sixmycat.catchy.exception.ErrorCode;
-import com.sixmycat.catchy.feature.feed.query.dto.response.AuthorInfo;
-import com.sixmycat.catchy.feature.feed.query.dto.response.CommentPreview;
-import com.sixmycat.catchy.feature.feed.query.dto.response.FeedBaseInfo;
-import com.sixmycat.catchy.feature.feed.query.dto.response.FeedDetailResponse;
+import com.sixmycat.catchy.feature.feed.query.dto.response.*;
 import com.sixmycat.catchy.feature.feed.query.mapper.FeedQueryMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -55,5 +55,12 @@ public class FeedQueryServiceImpl implements FeedQueryService {
                 .isMine(isMine)
                 .createdAt(baseInfo.getCreatedAt())
                 .build();
+    }
+
+    @Override
+    public PageResponse<FeedSummaryResponse> getMyFeeds(Long memberId, int page, int size) {
+        PageHelper.startPage(page + 1, size); // PageHelper는 1부터 시작
+        List<FeedSummaryResponse> list = feedQueryMapper.findMyFeeds(memberId);
+        return PageResponse.from(new PageInfo<>(list));
     }
 }

--- a/src/main/resources/mappers/feed/FeedQueryMapper.xml
+++ b/src/main/resources/mappers/feed/FeedQueryMapper.xml
@@ -55,4 +55,20 @@
         )
     </select>
 
+    <select id="findMyFeeds" resultType="com.sixmycat.catchy.feature.feed.query.dto.response.FeedSummaryResponse">
+        SELECT
+        f.id AS feedId,
+        (
+        SELECT fi.image_url
+        FROM feed_image fi
+        WHERE fi.feed_id = f.id
+        ORDER BY fi.sequence ASC
+        LIMIT 1
+        ) AS thumbnailUrl,
+        f.created_at
+        FROM feed f
+        WHERE f.member_id = #{memberId}
+        ORDER BY f.created_at DESC
+    </select>
+
 </mapper>

--- a/src/test/java/com/sixmycat/catchy/feature/feed/query/service/FeedQueryServiceImplTest.java
+++ b/src/test/java/com/sixmycat/catchy/feature/feed/query/service/FeedQueryServiceImplTest.java
@@ -1,10 +1,12 @@
 package com.sixmycat.catchy.feature.feed.query.service;
 
+import com.sixmycat.catchy.common.dto.PageResponse;
 import com.sixmycat.catchy.exception.BusinessException;
 import com.sixmycat.catchy.exception.ErrorCode;
 import com.sixmycat.catchy.feature.feed.query.dto.response.CommentPreview;
 import com.sixmycat.catchy.feature.feed.query.dto.response.FeedBaseInfo;
 import com.sixmycat.catchy.feature.feed.query.dto.response.FeedDetailResponse;
+import com.sixmycat.catchy.feature.feed.query.dto.response.FeedSummaryResponse;
 import com.sixmycat.catchy.feature.feed.query.mapper.FeedQueryMapper;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -81,5 +83,33 @@ class FeedQueryServiceImplTest {
         assertThatThrownBy(() -> feedQueryService.getFeedDetail(feedId, 10L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.FEED_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void shouldReturnMyFeedListSuccessfully() {
+        // given
+        Long memberId = 1L;
+        int page = 0;
+        int size = 10;
+
+        List<FeedSummaryResponse> mockList = List.of(
+                FeedSummaryResponse.builder()
+                        .feedId(1L)
+                        .thumbnailUrl("https://example.com/image1.jpg")
+                        .build(),
+                FeedSummaryResponse.builder()
+                        .feedId(2L)
+                        .thumbnailUrl("https://example.com/image2.jpg")
+                        .build()
+        );
+
+        when(feedQueryMapper.findMyFeeds(memberId)).thenReturn(mockList);
+
+        // when
+        PageResponse<FeedSummaryResponse> result = feedQueryService.getMyFeeds(memberId, page, size);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getFeedId()).isEqualTo(1L);
     }
 }


### PR DESCRIPTION
### 🛰️ Issue
- 본인 피드 목록 조회 기능 구현

### 🪐 작업 내용
- 본인 피드 목록 조회 기능 구현

### ✅ Check List (선택)
- [x] 단위 테스트 코드 작성 
- [x] Postman API 테스트