### PR TITLE
[BE] Cat 85 be 로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
 
 	implementation 'org.modelmapper:modelmapper:3.2.1'
 

--- a/src/main/java/com/sixmycat/catchy/config/SecurityConfig.java
+++ b/src/main/java/com/sixmycat/catchy/config/SecurityConfig.java
@@ -45,12 +45,12 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/oauth2/authorization/naver",
                                 "/api/v1/members/signup/naver/callback",
+                                "/api/v1/members/signup/extra",
+                                "/api/v1/members/temp-info",
                                 "/signup.html",
                                 "/signup-extra.html",
                                 "/token.html",
-                                "/login.html",
-                                "/api/v1/members/signup/extra",
-                                "/api/v1/members/temp-info"
+                                "/login.html"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/controller/AuthController.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/controller/AuthController.java
@@ -6,6 +6,8 @@ import com.sixmycat.catchy.feature.auth.command.application.dto.request.ExtraSig
 import com.sixmycat.catchy.feature.auth.command.application.dto.response.SocialLoginResponse;
 import com.sixmycat.catchy.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,5 +28,30 @@ public class AuthController {
     public ResponseEntity<ApiResponse<TempMember>> getTempInfo(@RequestParam String email, @RequestParam String social) {
         TempMember temp = authCommandService.getTempMember(email, social.toUpperCase());
         return ResponseEntity.ok(ApiResponse.success(temp));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken
+    ) {
+        if (refreshToken != null) {
+            authCommandService.logout(refreshToken);
+        }
+
+        ResponseCookie deleteCookie = createDeleteRefreshTokenCookie();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
+                .body(ApiResponse.success(null));
+    }
+
+
+    private ResponseCookie createDeleteRefreshTokenCookie() {
+        return ResponseCookie.from("refreshToken", "")
+                .path("/")
+                .maxAge(0)
+                .httpOnly(true)
+                .secure(true) // 배포 환경에서는 true
+                .sameSite("Lax") // 필요 시 Strict, None 등으로 변경
+                .build();
     }
 }

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandService.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandService.java
@@ -7,4 +7,5 @@ import com.sixmycat.catchy.feature.auth.command.domain.aggregate.TempMember;
 public interface AuthCommandService {
     SocialLoginResponse registerNewMember(ExtraSignupRequest request);
     TempMember getTempMember(String email, String social);
+    void logout(String refreshToken);
 }

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -106,5 +107,19 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             throw new BusinessException(ErrorCode.TEMP_MEMBER_NOT_FOUND);
         }
         return temp;
+    }
+
+    @Override
+    public void logout(String refreshToken) {
+        Set<String> keys = refreshTokenRedisTemplate.keys("REFRESH_TOKEN:*");
+        if (keys != null) {
+            for (String key : keys) {
+                RefreshToken storedToken = refreshTokenRedisTemplate.opsForValue().get(key);
+                if (storedToken != null && refreshToken.equals(storedToken.getToken())) {
+                    refreshTokenRedisTemplate.delete(key);
+                    break;
+                }
+            }
+        }
     }
 }

--- a/src/test/java/com/sixmycat/catchy/feature/auth/RedisRefreshTokenTest.java
+++ b/src/test/java/com/sixmycat/catchy/feature/auth/RedisRefreshTokenTest.java
@@ -1,4 +1,4 @@
-package com.sixmycat.catchy.common.auth;
+package com.sixmycat.catchy.feature.auth;
 
 import com.sixmycat.catchy.feature.auth.command.domain.aggregate.RefreshToken;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/com/sixmycat/catchy/feature/auth/command/application/controller/AuthControllerTest.java
+++ b/src/test/java/com/sixmycat/catchy/feature/auth/command/application/controller/AuthControllerTest.java
@@ -24,6 +24,7 @@ class AuthControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @SuppressWarnings("removal")
     @MockBean
     private AuthCommandService authCommandService;
 

--- a/src/test/java/com/sixmycat/catchy/feature/auth/command/application/controller/AuthControllerTest.java
+++ b/src/test/java/com/sixmycat/catchy/feature/auth/command/application/controller/AuthControllerTest.java
@@ -1,0 +1,54 @@
+package com.sixmycat.catchy.feature.auth.command.application.controller;
+
+import com.sixmycat.catchy.feature.auth.command.application.service.AuthCommandService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import jakarta.servlet.http.Cookie;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthCommandService authCommandService;
+
+    @Test
+    @WithMockUser(username = "10") // 이 부분을 본인 테이터베이스에 있는 member 의 id 값이어야 함!!
+    @DisplayName("로그아웃 성공 - accessToken과 refreshToken이 올바르게 주어진 경우")
+    void logout_success() throws Exception {
+        // given
+        String accessToken = "mockAccessToken";
+        String refreshToken = "mockRefreshToken";
+
+        // when
+        MockHttpServletRequestBuilder request = post("/api/v1/members/logout")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .cookie(new Cookie("refreshToken", refreshToken))
+                .with(csrf());
+
+        // then
+        mockMvc.perform(request)
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, org.hamcrest.Matchers.containsString("refreshToken=;")))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.errorCode").doesNotExist());
+
+        // verify
+        verify(authCommandService).logout(refreshToken);
+    }
+}


### PR DESCRIPTION
### 🛰️ Issue
로그아웃 기능 구현

### 🪐 작업 내용
authotization 값이랑 cookie 에 있는 refresh 토큰 값을 받아 레디스에 저장된 데이터를 삭제하는 작업을 수행합니다.

테스트는 2가지 방식이 있습니다.

##### 1. postman
![image](https://github.com/user-attachments/assets/0a286ec9-694b-4f76-9d75-1a4aae066a37)
해당 이미지의 내용과 같이 주소를 입력하고 오른쪽의 send 버튼 아래의 Cookie 버튼을 클릭한다.


![image](https://github.com/user-attachments/assets/b3290b43-9b71-411b-a8ad-8f0254fbe666)
입력창에 localhost 를 입력하고 Add domian 을 클릭한다.


![image](https://github.com/user-attachments/assets/53322c79-04fe-4f7e-b587-cf4f247b9117)
+Add Cookie 를 클릭한다.


![image](https://github.com/user-attachments/assets/2ed154c2-c16b-49bd-981e-e320fbe7eab6)
입력칸에 해당 내용을 입력한다. 단, your_refresh_token_value 값에  로그아웃 할 계정의 refresh token 값을 넣는다.


![image](https://github.com/user-attachments/assets/8aac8d73-b827-49cd-91ad-242abc50e0f1)
Authorization 에서 Auth Type 을 Bearer Token 값으로 하고 로그아웃 할 계정의 access token 값을 넣는다.

send를 보내서 로그아웃 기능을 테스트 한다.

예상 response 값
```
{
    "success": true,
    "data": null,
    "errorCode": null,
    "message": null,
    "timestamp": "2025-05-19T02:47:22.346264"
}
```
+) 레디스에 저장되어 있던 유저의 refresh 토큰 데이터 값도 삭제되어 있어야 합니다.


##### 2. Test 코드
AuthControllerTest 코드에서@WithMockUser(username = "10") 부분에 본인 테이터베이스에 있는 member 의 id 값을 넣어줘야 한다.
```
    @Test
    @WithMockUser(username = "10") // 이 부분을 본인 테이터베이스에 있는 member 의 id 값이어야 함!!
    @DisplayName("로그아웃 성공 - accessToken과 refreshToken이 올바르게 주어진 경우")
```
+) 'org.springframework.boot.test.mock.mockito.MockBean'은(는) 버전 3.4.0 이후 사용되지 않으며 제거될 예정입니다
위의 오류가 뜰텐데, 이 메시지는 "삭제 예정 경고"일 뿐 실제 에러는 아니기 때문에 테스트 코드를 실행하는 데 문제는 없습니다.



### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [ ] 컨벤션 맞게 확인했는지
- [ ] 로그아웃 기능 잘 실행되는지