### PR TITLE
feat: 로그인 테스트 다시 복구

### DIFF
--- a/src/main/java/com/sixmycat/catchy/config/SecurityConfig.java
+++ b/src/main/java/com/sixmycat/catchy/config/SecurityConfig.java
@@ -50,6 +50,10 @@ public class SecurityConfig {
                                 "/signup.html",
                                 "/signup-extra.html",
                                 "/token.html",
+                                "/login.html",
+                                "/api/v1/members/signup/extra",
+                                "/api/v1/members/temp-info",
+                                "/api/v1/members/login/test"
                                 "/login.html"
                                 "/login.html",
                                 "/api/v1/members/signup/extra",

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/controller/AuthController.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/controller/AuthController.java
@@ -34,6 +34,23 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success(temp));
     }
 
+    /* 테스트 로그인 */
+    @Operation(summary = "테스트용 로그인", description = "테스트용 로그인 후 JWT를 발급합니다.")
+    @PostMapping("/login/test")
+    public ResponseEntity<ApiResponse<TokenResponse>> login(){
+        TokenResponse token = authCommandService.testLogin();
+        return buildTokenResponse(token);
+    }
+
+
+    /* accessToken 과 refreshToken을 body와 쿠키에 담아 반환 */
+    private ResponseEntity<ApiResponse<TokenResponse>> buildTokenResponse(TokenResponse tokenResponse) {
+        ResponseCookie cookie = createRefreshTokenCookie(tokenResponse.getRefreshToken());  // refreshToken 쿠키 생성
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(ApiResponse.success(tokenResponse));
+    }
+
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @CookieValue(name = "refreshToken", required = false) String refreshToken

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandService.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandService.java
@@ -8,6 +8,7 @@ import com.sixmycat.catchy.feature.auth.command.domain.aggregate.TempMember;
 public interface AuthCommandService {
     SocialLoginResponse registerNewMember(ExtraSignupRequest request);
     TempMember getTempMember(String email, String social);
+    TokenResponse testLogin();
     void logout(String refreshToken);
     TokenResponse testLogin();
 }

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandServiceImpl.java
@@ -111,6 +111,21 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         return temp;
     }
 
+    /* 테스트 로그인  */
+    @Transactional
+    public TokenResponse testLogin() {
+
+        // 토큰 발급
+        String accessToken = jwtTokenProvider.createToken(1L);
+        String refreshToken = jwtTokenProvider.createRefreshToken(1L);
+
+        return TokenResponse
+                .builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
     @Override
     public void logout(String refreshToken) {
         Set<String> keys = refreshTokenRedisTemplate.keys("REFRESH_TOKEN:*");


### PR DESCRIPTION
🛠 쭈르 수정 API PR
✅ 주요 변경 사항
쭈르(Jjure) 콘텐츠 수정 기능 추가
로그인한 사용자가 본인이 작성한 쭈르의 caption, fileKey를 수정할 수 있도록 구현
수정 요청은 PUT 메서드를 사용하며, jjureId를 경로 변수로 전달
📌 1. API 스펙
HTTP Method: PUT
URI: /jjure/{jjureId}
Request Body:
{
  "caption": "수정된 캡션입니다.",
  "fileKey": "uploads/새로운-파일키.mp4"
}
- Response:
```java
{
  "success": true,
  "data": {
    "jjureId": 1,
    "caption": "수정된 캡션입니다.",
    "fileKey": "uploads/새로운-파일키.mp4"
  }
}
🛠 2. 기능 상세 설명
jjureId를 기준으로 DB에서 기존 쭈르를 조회
로그인한 사용자의 ID와 해당 쭈르의 작성자가 일치하는지 검증
caption, fileKey 필드를 수정한 후 저장
수정 성공 시 ApiResponse.success() 형식으로 응답
⚠️ 3. 예외 처리
존재하지 않는 jjureId 요청: JJURE_NOT_FOUND
작성자가 아닌 사용자가 수정 시도: FORBIDDEN_JJURE_ACCESS
caption, fileKey 유효성 오류: INVALID_INPUT_VALUE
🧪 4. 테스트 항목

성공 케이스

작성자가 caption과 fileKey를 수정 요청하면 정상적으로 수정되고 200 응답 반환
실패 케이스

존재하지 않는 jjureId → 404
작성자가 아닌 사용자가 요청 → 403
caption 또는 fileKey 누락 → 400