### PR TITLE
feat: 30일이 지난 알림 자동 삭제

### DIFF
--- a/src/main/java/com/sixmycat/catchy/config/SchedulerConfig.java
+++ b/src/main/java/com/sixmycat/catchy/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.sixmycat.catchy.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/sixmycat/catchy/feature/notification/command/application/service/NotificationCleanupService.java
+++ b/src/main/java/com/sixmycat/catchy/feature/notification/command/application/service/NotificationCleanupService.java
@@ -1,0 +1,24 @@
+package com.sixmycat.catchy.feature.notification.command.application.service;
+
+import com.sixmycat.catchy.feature.notification.command.domain.repository.NotificationRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationCleanupService {
+
+    private final NotificationRepository notificationRepository;
+
+    // 매일 새벽 2시에 실행
+    @Transactional
+    @Scheduled(cron = "0 0 2 * * *")
+    public void deleteOldNotifications() {
+        LocalDateTime thresholdDate = LocalDateTime.now().minusDays(30);
+        notificationRepository.deleteNotificationsOlderThan(thresholdDate);
+    }
+}

--- a/src/main/java/com/sixmycat/catchy/feature/notification/command/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sixmycat/catchy/feature/notification/command/domain/repository/NotificationRepository.java
@@ -1,7 +1,20 @@
 package com.sixmycat.catchy.feature.notification.command.domain.repository;
 
 import com.sixmycat.catchy.feature.notification.command.domain.aggregate.Notification;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+
+@Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE n.createdAt < :thresholdDate")
+    void deleteNotificationsOlderThan(@Param("thresholdDate") LocalDateTime thresholdDate);
+
 }

--- a/src/test/java/com/sixmycat/catchy/feature/notification/command/application/service/NotificationCleanupServiceTest.java
+++ b/src/test/java/com/sixmycat/catchy/feature/notification/command/application/service/NotificationCleanupServiceTest.java
@@ -1,0 +1,43 @@
+package com.sixmycat.catchy.feature.notification.command.application.service;
+
+import com.sixmycat.catchy.feature.notification.command.domain.repository.NotificationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationCleanupServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationCleanupService notificationCleanupService;
+
+    @Test
+    public void deleteOldNotifications_shouldCallRepositoryWithCorrectDate() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expectedThreshold = now.minusDays(30);
+
+        // when
+        notificationCleanupService.deleteOldNotifications();
+
+        // then
+        ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(notificationRepository, times(1)).deleteNotificationsOlderThan(captor.capture());
+
+        // 이건 조금 유연하게 비교 (날짜 차이 허용)
+        assertTrue(Duration.between(expectedThreshold, captor.getValue()).abs().getSeconds() < 5);
+    }
+}


### PR DESCRIPTION
### 🛰️ Issue
feat: 30일이 지난 알림 자동 삭제

### 🪐 작업 내용
schedulerConfig 이용해 스케줄러 활성화, 자동으로 매일 새벽 2시에 해당 서비스가 실행되도록 설정 완료

![image](https://github.com/user-attachments/assets/70e3aa59-0ecb-462b-822a-f5fd0194a5ea)
![image](https://github.com/user-attachments/assets/ad687887-12ef-4a7f-b61d-16d578f613d3)


### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [x] 서비스 단위 테스트 완료
- [ ]