### PR TITLE
feat: 회원가입 할 때 등록한 이미지를 s3를 통해 저장

### DIFF
--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/controller/AuthController.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/controller/AuthController.java
@@ -94,7 +94,7 @@ public class AuthController {
     }
 
     @DeleteMapping
-    public ResponseEntity<ApiResponse<Void>> withdraw(
+    public ResponseEntity<ApiResponse<Void>> delete(
             @CookieValue(name = "refreshToken", required = false) String refreshToken
     ) {
         if (refreshToken != null) {

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/dto/request/ExtraSignupRequest.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/dto/request/ExtraSignupRequest.java
@@ -1,18 +1,14 @@
 package com.sixmycat.catchy.feature.auth.command.application.dto.request;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.*;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class ExtraSignupRequest {
     private String email;
     private String contactNumber;
     private String nickname;
-    private String social;
     private String name;
 }

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandService.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandService.java
@@ -4,9 +4,10 @@ import com.sixmycat.catchy.common.dto.TokenResponse;
 import com.sixmycat.catchy.feature.auth.command.application.dto.request.ExtraSignupRequest;
 import com.sixmycat.catchy.feature.auth.command.application.dto.response.SocialLoginResponse;
 import com.sixmycat.catchy.feature.auth.command.domain.aggregate.TempMember;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface AuthCommandService {
-    SocialLoginResponse registerNewMember(ExtraSignupRequest request);
+    SocialLoginResponse registerNewMember(ExtraSignupRequest request, MultipartFile profileImage);
     TempMember getTempMember(String email, String social);
     TokenResponse testLogin();
     void logout(String refreshToken);

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandServiceImpl.java
@@ -2,6 +2,7 @@ package com.sixmycat.catchy.feature.auth.command.application.service;
 
 import com.sixmycat.catchy.common.dto.TokenResponse;
 import com.sixmycat.catchy.common.utils.NicknameValidator;
+import com.sixmycat.catchy.common.s3.S3Uploader;
 import com.sixmycat.catchy.exception.BusinessException;
 import com.sixmycat.catchy.exception.ErrorCode;
 import com.sixmycat.catchy.feature.auth.command.domain.aggregate.RefreshToken;
@@ -17,6 +18,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.Duration;
 import java.util.Set;
@@ -34,56 +36,66 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     private final RedisTemplate<String, RefreshToken> refreshTokenRedisTemplate;
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final S3Uploader s3Uploader;
 
     @Value("${jwt.refresh-expiration}")
     private Long refreshTokenExpiration;
 
     @Override
-    public SocialLoginResponse registerNewMember(ExtraSignupRequest request) {
-        String key = switch (request.getSocial().toUpperCase()) {
-            case "NAVER" -> "TEMP_N_MEMBER:" + request.getEmail();
-            case "KAKAO" -> "TEMP_K_MEMBER:" + request.getEmail();
-            default -> throw new BusinessException(ErrorCode.SOCIAL_PLATFORM_NOT_SUPPORTED);
-        };
+    public SocialLoginResponse registerNewMember(ExtraSignupRequest request, MultipartFile profileImage) {
+        // Redis 키를 이메일 기반으로 두 가지 방식 모두 확인
+        String email = request.getEmail();
+        String naverKey = "TEMP_N_MEMBER:" + email;
+        String kakaoKey = "TEMP_K_MEMBER:" + email;
 
-        TempMember temp = redisTemplate.opsForValue().get(key);
+        TempMember temp = null;
+        String redisKey = null;
+
+        if (redisTemplate.hasKey(naverKey)) {
+            temp = redisTemplate.opsForValue().get(naverKey);
+            redisKey = naverKey;
+        } else if (redisTemplate.hasKey(kakaoKey)) {
+            temp = redisTemplate.opsForValue().get(kakaoKey);
+            redisKey = kakaoKey;
+        }
+
         if (temp == null) {
             throw new BusinessException(ErrorCode.TEMP_MEMBER_NOT_FOUND);
         }
 
+        // 닉네임 검증
         String nickname = request.getNickname();
-
-        // 닉네임 공백 검사
         if (NicknameValidator.isEmptyOrBlank(nickname)) {
             throw new BusinessException(ErrorCode.EMPTY_OR_BLANK_NICKNAME);
         }
-
-        // 닉네임 길이 검사
         if (!NicknameValidator.isLengthValid(nickname)) {
             throw new BusinessException(ErrorCode.WRONG_NICKNAME_LENGTH);
         }
-
-        // 닉네임 유효성 검사
         if (!NicknameValidator.isPatternValid(nickname)) {
             throw new BusinessException(ErrorCode.INVALID_NICKNAME_FORMAT);
         }
-
-        // 닉네임 중복 검사
         if (memberRepository.existsByNicknameAndDeletedAtIsNull(nickname)) {
             throw new BusinessException(ErrorCode.USING_NICKNAME);
         }
 
+        // S3에 이미지 업로드 (null 허용)
+        String profileImageUrl = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            profileImageUrl = s3Uploader.uploadFile(profileImage, "profile");
+        }
+
+        // 최종 Member 저장
         Member member = Member.builder()
                 .email(temp.getEmail())
-                .social(temp.getSocial())
-                .profileImage(temp.getProfileImage())
+                .social(temp.getSocial()) // Redis에 저장된 social 값 사용
                 .name(request.getName())
                 .contactNumber(request.getContactNumber())
                 .nickname(nickname)
+                .profileImage(profileImageUrl)
                 .build();
 
         memberRepository.save(member);
-        redisTemplate.delete(key);
+        redisTemplate.delete(redisKey); // 사용 완료 후 삭제
 
         Long memberId = member.getId();
         String accessToken = jwtTokenProvider.createToken(memberId);
@@ -113,16 +125,12 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         return temp;
     }
 
-    /* 테스트 로그인  */
-    @Transactional
+    @Override
     public TokenResponse testLogin() {
-
-        // 토큰 발급
         String accessToken = jwtTokenProvider.createToken(1L);
         String refreshToken = jwtTokenProvider.createRefreshToken(1L);
 
-        return TokenResponse
-                .builder()
+        return TokenResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
@@ -145,26 +153,19 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     @Override
     @Transactional
     public void delete(String refreshToken) {
-        // Redis에서 memberId 찾기
         Set<String> keys = refreshTokenRedisTemplate.keys("REFRESH_TOKEN:*");
         if (keys == null) return;
 
         for (String key : keys) {
             RefreshToken storedToken = refreshTokenRedisTemplate.opsForValue().get(key);
             if (storedToken != null && refreshToken.equals(storedToken.getToken())) {
-                // key: REFRESH_TOKEN:{memberId}
                 Long memberId = Long.parseLong(key.split(":")[1]);
 
-                // DB에서 회원 조회 및 탈퇴 처리
                 Member member = memberRepository.findById(memberId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-
                 member.updateDeletedAt();
-
-                // 저장
                 memberRepository.save(member);
 
-                // Redis에서 refreshToken 제거
                 refreshTokenRedisTemplate.delete(key);
                 break;
             }

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/domain/aggregate/TempMember.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/domain/aggregate/TempMember.java
@@ -12,7 +12,6 @@ import java.io.Serializable;
 public class TempMember implements Serializable {
     private String email;
     private String social;
-    private String profileImage;
     private String name;
     private String contactNumber;
 }

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/domain/service/OAuth2UserInfoExtractorImpl.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/domain/service/OAuth2UserInfoExtractorImpl.java
@@ -28,7 +28,6 @@ public class OAuth2UserInfoExtractorImpl implements OAuth2UserInfoExtractor {
                 .social(platform.toUpperCase())
                 .name(extractName(user, platform))
                 .contactNumber(extractPhone(user, platform))
-                .profileImage(extractProfileImage(user, platform))
                 .build();
     }
 
@@ -59,24 +58,4 @@ public class OAuth2UserInfoExtractorImpl implements OAuth2UserInfoExtractor {
         Object phoneNumber = kakaoAccount.get("phone_number");
         return phoneNumber != null ? phoneNumber.toString() : null;
     }
-
-
-    private String extractProfileImage(DefaultOAuth2User user, String platform) {
-        if (!platform.equals("kakao")) {
-            Map<String, Object> response = (Map<String, Object>) user.getAttributes().get("response");
-            if (response == null) return null;
-            Object image = response.get("profile_image");
-            return image != null ? image.toString() : null;
-        }
-
-        Map<String, Object> kakaoAccount = (Map<String, Object>) user.getAttributes().get("kakao_account");
-        if (kakaoAccount == null) return null;
-
-        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
-        if (profile == null) return null;
-
-        Object profileImage = profile.get("profile_image_url");
-        return profileImage != null ? profileImage.toString() : null;
-    }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,7 +71,6 @@ spring:
             authorization-grant-type: authorization_code
             scope:
               - account_email
-              - profile_image
         provider:
           naver:
             authorization-uri: https://nid.naver.com/oauth2.0/authorize

--- a/src/main/resources/static/signup-extra.html
+++ b/src/main/resources/static/signup-extra.html
@@ -6,10 +6,12 @@
 </head>
 <body>
 <h1>추가 정보 입력</h1>
-<form id="extra-form">
+
+<form id="extra-form" enctype="multipart/form-data">
     <label>이름: <input type="text" name="name" id="name" required /></label><br/>
     <label>전화번호: <input type="text" name="contactNumber" id="contactNumber" required /></label><br/>
     <label>닉네임: <input type="text" name="nickname" id="nickname" required /></label><br/>
+    <label>프로필 이미지: <input type="file" name="profileImage" id="profileImage" accept="image/*" /></label><br/>
     <button type="submit">회원가입 완료</button>
 </form>
 
@@ -32,7 +34,7 @@
             if (data.name) {
                 const input = document.getElementById('name');
                 input.value = data.name;
-                input.readOnly = true; // 수정 불가지만 전송은 가능
+                input.readOnly = true;
             }
 
             if (data.contactNumber) {
@@ -50,23 +52,31 @@
         e.preventDefault();
 
         const form = e.target;
-        const data = {
-            email: email,
-            social: social.toUpperCase(),
-            name: form.name.value,
-            contactNumber: form.contactNumber.value.replace(/-/g, ''),
-            nickname: form.nickname.value
-        };
-        console.log("[회원가입 요청 데이터]", data);
+        const formData = new FormData();
 
-        const res = await fetch('http://localhost:8000/api/v1/members/signup/extra', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(data)
-        });
+        formData.append("email", email);
+        formData.append("social", social.toUpperCase());
+        formData.append("name", form.name.value);
+        formData.append("contactNumber", form.contactNumber.value.replace(/-/g, ''));
+        formData.append("nickname", form.nickname.value);
 
-        const result = await res.json();
-        document.getElementById('result').textContent = JSON.stringify(result, null, 2);
+        const profileImage = document.getElementById("profileImage").files[0];
+        if (profileImage) {
+            formData.append("profileImage", profileImage);
+        }
+
+        try {
+            const res = await fetch('http://localhost:8000/api/v1/members/signup/extra', {
+                method: 'POST',
+                body: formData
+            });
+
+            const result = await res.json();
+            document.getElementById('result').textContent = JSON.stringify(result, null, 2);
+        } catch (err) {
+            console.error("회원가입 요청 실패:", err);
+            alert("회원가입에 실패했습니다.");
+        }
     });
 </script>
 </body>


### PR DESCRIPTION
### 🛰️ Issue
회원가입 할 때 등록한 이미지를 s3를 통해 저장

### 🪐 작업 내용
기존의 db에 profile_image 에 바로 이미지 파일을 넣었던 방식을 s3에 저장하고 받은 url 값을 db에 저장하는 방식으로 변경하였습니다.

### 📚 논의하고싶은 내용 (선택)
회원 탈퇴 할 때도 s3에 업로드 되어 있던 사진을 삭제 후 탈퇴를 진행하도록 코드를 수정하려고 했지만 실제로 사진이 지워지는지 확인을 할 수 없어 내일 추가로 작업 해두겠습니다.

### ✅ Check List (선택)
- [ ] 컨벤션 맞게 작성했는지
- [ ] 코드 잘 돌아가는지