### PR TITLE
refactor: 토큰 재발급 기능 수정

### DIFF
--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/dto/response/SocialLoginResponse.java
@@ -10,27 +10,25 @@ public class SocialLoginResponse {
     private final String email;
     private final Long id;
     private final String accessToken;
-    private final String refreshToken;
 
     // 명시적 생성자
-    public SocialLoginResponse(boolean isNewUser, String email, Long id, String accessToken, String refreshToken) {
+    public SocialLoginResponse(boolean isNewUser, String email, Long id, String accessToken) {
         this.isNewUser = isNewUser;
         this.email = email;
         this.id = id;
         this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
     }
 
     // 정적 생성 메서드
-    public static SocialLoginResponse loggedIn(Long id, String accessToken, String refreshToken) {
-        return new SocialLoginResponse(false, null, id, accessToken, refreshToken);
+    public static SocialLoginResponse loggedIn(Long id, String accessToken) {
+        return new SocialLoginResponse(false, null, id, accessToken);
     }
 
     public static SocialLoginResponse requireAdditionalInfo(String email) {
-        return new SocialLoginResponse(true, email, null, null, null);
+        return new SocialLoginResponse(true, email, null, null);
     }
 
     public static SocialLoginResponse loggedInWithoutRefresh(Long id, String accessToken) {
-        return new SocialLoginResponse(false, null, id, accessToken, null);
+        return new SocialLoginResponse(false, null, id, accessToken);
     }
 }

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/dto/response/SocialLoginResultResponse.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/dto/response/SocialLoginResultResponse.java
@@ -1,0 +1,19 @@
+package com.sixmycat.catchy.feature.auth.command.application.dto.response;
+
+public class SocialLoginResultResponse {
+    private final SocialLoginResponse response;
+    private final String refreshToken;
+
+    public SocialLoginResultResponse(SocialLoginResponse response, String refreshToken) {
+        this.response = response;
+        this.refreshToken = refreshToken;
+    }
+
+    public SocialLoginResponse getResponse() {
+        return response;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+}

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/dto/response/SocialLoginResultResponse.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/dto/response/SocialLoginResultResponse.java
@@ -1,5 +1,10 @@
 package com.sixmycat.catchy.feature.auth.command.application.dto.response;
 
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class SocialLoginResultResponse {
     private final SocialLoginResponse response;
     private final String refreshToken;
@@ -7,13 +12,5 @@ public class SocialLoginResultResponse {
     public SocialLoginResultResponse(SocialLoginResponse response, String refreshToken) {
         this.response = response;
         this.refreshToken = refreshToken;
-    }
-
-    public SocialLoginResponse getResponse() {
-        return response;
-    }
-
-    public String getRefreshToken() {
-        return refreshToken;
     }
 }

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandService.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandService.java
@@ -3,11 +3,12 @@ package com.sixmycat.catchy.feature.auth.command.application.service;
 import com.sixmycat.catchy.common.dto.TokenResponse;
 import com.sixmycat.catchy.feature.auth.command.application.dto.request.ExtraSignupRequest;
 import com.sixmycat.catchy.feature.auth.command.application.dto.response.SocialLoginResponse;
+import com.sixmycat.catchy.feature.auth.command.application.dto.response.SocialLoginResultResponse;
 import com.sixmycat.catchy.feature.auth.command.domain.aggregate.TempMember;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AuthCommandService {
-    SocialLoginResponse registerNewMember(ExtraSignupRequest request, MultipartFile profileImage);
+    SocialLoginResultResponse registerNewMember(ExtraSignupRequest request, MultipartFile profileImage);
     TempMember getTempMember(String email, String social);
     TokenResponse testLogin();
     void logout(String refreshToken);

--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.sixmycat.catchy.common.utils.NicknameValidator;
 import com.sixmycat.catchy.common.s3.S3Uploader;
 import com.sixmycat.catchy.exception.BusinessException;
 import com.sixmycat.catchy.exception.ErrorCode;
+import com.sixmycat.catchy.feature.auth.command.application.dto.response.SocialLoginResultResponse;
 import com.sixmycat.catchy.feature.auth.command.domain.aggregate.RefreshToken;
 import com.sixmycat.catchy.feature.auth.command.domain.aggregate.TempMember;
 import com.sixmycat.catchy.feature.auth.command.application.dto.request.ExtraSignupRequest;
@@ -38,7 +39,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     private final S3Uploader s3Uploader;
 
     @Override
-    public SocialLoginResponse registerNewMember(ExtraSignupRequest request, MultipartFile profileImage) {
+    public SocialLoginResultResponse registerNewMember(ExtraSignupRequest request, MultipartFile profileImage) {
         // Redis 키를 이메일 기반으로 두 가지 방식 모두 확인
         String email = request.getEmail();
         String naverKey = "TEMP_N_MEMBER:" + email;
@@ -103,7 +104,10 @@ public class AuthCommandServiceImpl implements AuthCommandService {
                 Duration.ofMillis(jwtTokenProvider.getRefreshTokenExpiration())
         );
 
-        return SocialLoginResponse.loggedIn(memberId, accessToken, refreshToken);
+        return new SocialLoginResultResponse(
+                SocialLoginResponse.loggedIn(memberId, accessToken),
+                refreshToken
+        );
     }
 
     @Override


### PR DESCRIPTION
### 🛰️ Issue
토큰 재발급 기능 수정

### 🪐 작업 내용
개발 초기에 급하게 만든 토큰 재발급 기능을 수정하였습니다.
토큰 재발급은 access token 을 재발급 하는 기능이기 때문에 쿠키나 반환값에 refresh token 값은 들어가 있지 않습니다.
추가 작업으로 회원가입과 로그인을 할 때 refreshToken은 cookie로 주기 때문에 json 반환값에 refreshToken 값이 null 로 표기되는 필요없는 부분을 삭제하였습니다.

#### 테스트 방식
![image](https://github.com/user-attachments/assets/a458dfd2-d335-4402-8be2-d5ea8b32c70c)
위의 사진과 같이 headers 에 Cookie 를 추가하여 Value 에 refreshToken 값을 추가한 뒤 send 를 하면 됩니다.

예상 반환값 (성공)
```
{
    "success": true,
    "data": {
        "email": null,
        "id": 2,
        "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIyIiwiaWF0IjoxNzQ3NzA4OTI3LCJleHAiOjE3NDc3MTA3Mjd9.7Ql5hVabl8QPsuHomDjkluAvPJW1K1bm_NXGNhMnZQz8_jzT7fcC_GBu0yVsJpBYde1n4QLIfA61IysfDQ70iA",
        "newUser": false
    },
    "errorCode": null,
    "message": null,
    "timestamp": "2025-05-20T11:42:07.862616"
}
```

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [ ] 컨벤션에 맞는지
- [ ] 코드 잘 돌아가는지