### PR TITLE
fix: 피드 리스트 비회원이어도 조회 가능하게 수정

### DIFF
--- a/src/main/java/com/sixmycat/catchy/config/SecurityConfig.java
+++ b/src/main/java/com/sixmycat/catchy/config/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
                                 "/static/token.html",
                                 "/static/login.html",
                                 "/api/v1/members/login/test",
-                                "/api/v1/profiles/{memberId}"
+                                "/api/v1/profiles/{memberId}",
+                                "/api/v1/feeds"
                         ).permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/members").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/members/me").authenticated()

--- a/src/main/java/com/sixmycat/catchy/feature/feed/query/controller/FeedQueryController.java
+++ b/src/main/java/com/sixmycat/catchy/feature/feed/query/controller/FeedQueryController.java
@@ -38,13 +38,21 @@ public class FeedQueryController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<FeedDetailResponse>>> getFeeds(
-            @AuthenticationPrincipal String memberId,
+            @AuthenticationPrincipal Object principal,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "5") int size
     ) {
-        PageResponse<FeedDetailResponse> response = feedQueryService.getFeedList(Long.parseLong(memberId), page, size);
+        Long memberId = null;
+        if (principal instanceof String str && !str.equals("anonymousUser")) {
+            try {
+                memberId = Long.parseLong(str);
+            } catch (NumberFormatException ignored) {}
+        }
+
+        PageResponse<FeedDetailResponse> response = feedQueryService.getFeedList(memberId, page, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
 
     @GetMapping("/likes")
     public ResponseEntity<ApiResponse<PageResponse<FeedSummaryResponse>>> getLikedFeeds(
@@ -53,16 +61,6 @@ public class FeedQueryController {
             @RequestParam(defaultValue = "5") int size
     ) {
         PageResponse<FeedSummaryResponse> response = feedQueryService.getLikedFeedList(Long.parseLong(memberId), page, size);
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
-    @GetMapping("/member/{memberId}")
-    public ResponseEntity<ApiResponse<PageResponse<FeedSummaryResponse>>> getFeedsByMemberId(
-            @PathVariable Long memberId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int size
-    ){
-        PageResponse<FeedSummaryResponse> response = feedQueryService.getFeedsByMemberId(memberId, page, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }


### PR DESCRIPTION
### 🛰️ Issue
피드 리스트 비회원이어도 조회 가능하게 수정

### 🪐 작업 내용
이전에 피드 리스트는 비회원이면 조회 불가능 -> 조회 가능하도록 수정

수정한 부분
- security config
- FeedQueryController

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [ ] 
- [ ]