### PR TITLE
Cat 252 fe 본인 피드 조회 controller추가 업로드 용량 제한 변경

### DIFF
--- a/src/main/java/com/sixmycat/catchy/feature/feed/query/controller/FeedQueryController.java
+++ b/src/main/java/com/sixmycat/catchy/feature/feed/query/controller/FeedQueryController.java
@@ -63,4 +63,16 @@ public class FeedQueryController {
         PageResponse<FeedSummaryResponse> response = feedQueryService.getLikedFeedList(Long.parseLong(memberId), page, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    @GetMapping("/member/{memberId}")
+    public ResponseEntity<ApiResponse<PageResponse<FeedSummaryResponse>>> getFeedsByMemberId(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
+
+    ) {
+        PageResponse<FeedSummaryResponse> response = feedQueryService.getFeedsByMemberId(memberId, page, size);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,6 +4,10 @@ server:
 spring:
   application:
     name: CATCHY
+  servlet:
+    multipart:
+      max-file-size: 30MB
+      max-request-size: 30MB
 
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver


### PR DESCRIPTION
### 🛰️ Issue
- 본인 피드 조회 controller추가 업로드 용량 제한 변경

### 🪐 작업 내용
- 본인 피드 조회 controller 추가
- 이미지 업로드 용량 제한 30MB로 변경
