### PR TITLE
fix: 로그인 시 url에 access token 보이는 것 수정

### DIFF
--- a/src/main/java/com/sixmycat/catchy/common/utils/CookieUtils.java
+++ b/src/main/java/com/sixmycat/catchy/common/utils/CookieUtils.java
@@ -29,4 +29,13 @@ public class CookieUtils {
                 .sameSite("Strict")
                 .build();
     }
+
+    public static ResponseCookie createAccessTokenCookie(String accessToken) {
+        return ResponseCookie.from("accessToken", accessToken)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(Duration.ofMinutes(30)) // 만료 시간 조정 가능
+                .sameSite("Strict")
+                .build();
+    }
 }

--- a/src/main/java/com/sixmycat/catchy/config/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sixmycat/catchy/config/OAuth2SuccessHandler.java
@@ -46,17 +46,24 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 authToken.getAuthorizedClientRegistrationId()
         );
 
-        // 기존 유저인 경우에만 refreshToken 쿠키 설정
+        // accessToken & refreshToken 쿠키 설정 (기존 유저만)
         if (!loginResponse.isNewUser()) {
             String refreshToken = (String) RequestContextHolder.getRequestAttributes()
                     .getAttribute("refreshToken", RequestAttributes.SCOPE_REQUEST);
+            String accessToken = (String) RequestContextHolder.getRequestAttributes()
+                    .getAttribute("accessToken", RequestAttributes.SCOPE_REQUEST);
+
             if (refreshToken != null) {
                 ResponseCookie cookie = CookieUtils.createRefreshTokenCookie(refreshToken);
                 response.addHeader("Set-Cookie", cookie.toString());
             }
+            if (accessToken != null) {
+                ResponseCookie cookie = CookieUtils.createAccessTokenCookie(accessToken);
+                response.addHeader("Set-Cookie", cookie.toString());
+            }
         }
 
-        // 분기: 신규 유저는 추가 정보 입력 페이지로 리디렉트
+        // 신규 유저는 추가 정보 입력 페이지로 리디렉트
         if (loginResponse.isNewUser()) {
             String social = authToken.getAuthorizedClientRegistrationId().toUpperCase(); // "NAVER" 또는 "KAKAO"
 
@@ -69,11 +76,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             return;
         }
 
-        // 기존 유저는 로그인 완료 페이지로 리디렉트
-        String redirectUrl = UriComponentsBuilder.fromUriString(loginSuccessPageUrl)
-                .queryParam("accessToken", loginResponse.getAccessToken())
-                .build().toUriString();
-
-        response.sendRedirect(redirectUrl);
+        response.sendRedirect(loginSuccessPageUrl);
     }
 }


### PR DESCRIPTION
### 🛰️ Issue
로그인 시 url에 access token 보이는 것 수정

### 🪐 작업 내용
oauth 를 통해 로그인을 실행 중인데, oauth 방식은 서버에서 직접 클라이언트(브라우저)로 리디렉트만 수행 가능합니다.
그래서 json 으로 액세스 토큰을 보내주는 것이 현재 로그인 방식에서는 불가능합니다.
그래서 로그인 방식에서는 access token 을 json으로 보내는 대신 쿠키로 주는 방식으로 수정하였습니다.

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)