### PR TITLE
feat: 차단한 회원 프로필 조회

### DIFF
--- a/src/main/java/com/sixmycat/catchy/feature/block/query/dto/response/BlockResponse.java
+++ b/src/main/java/com/sixmycat/catchy/feature/block/query/dto/response/BlockResponse.java
@@ -1,14 +1,19 @@
 package com.sixmycat.catchy.feature.block.query.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class BlockResponse {
     private Long blockedId;
     private String blockedNickname;
     private LocalDateTime blockedAt;
+    private String profileImage;
 }

--- a/src/main/resources/mappers/block/BlockQueryMapper.xml
+++ b/src/main/resources/mappers/block/BlockQueryMapper.xml
@@ -8,6 +8,7 @@
         SELECT
         b.blocked_id AS blockedId,
         m.nickname AS blockedNickname,
+        m.profile_image AS profileImage,
         b.blocked_at AS blockedAt
         FROM block b
         JOIN member m ON b.blocked_id = m.id


### PR DESCRIPTION
### 🛰️ Issue
차단한 회원 프로필 조회

### 🪐 작업 내용
기존에 차단한 회원의 프로필을 반환값으로 주고 있지 않았던 것을 조회할 때 이미지 값도 같이 주도록 수정했습니다.

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [ ] 
- [ ]