### PR TITLE
fix: 탈퇴한 유저의 닉네임 재사용 불가

### DIFF
--- a/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/sixmycat/catchy/feature/auth/command/application/service/AuthCommandServiceImpl.java
@@ -11,6 +11,7 @@ import com.sixmycat.catchy.feature.auth.command.domain.aggregate.TempMember;
 import com.sixmycat.catchy.feature.auth.command.application.dto.request.ExtraSignupRequest;
 import com.sixmycat.catchy.feature.auth.command.application.dto.response.SocialLoginResponse;
 import com.sixmycat.catchy.feature.auth.command.domain.service.JwtTokenDomainService;
+import com.sixmycat.catchy.feature.member.command.application.dto.request.AddCatRequest;
 import com.sixmycat.catchy.feature.member.command.domain.aggregate.Member;
 import com.sixmycat.catchy.feature.member.command.domain.repository.MemberRepository;
 import com.sixmycat.catchy.security.jwt.JwtTokenProvider;
@@ -23,6 +24,7 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Set;
 
 @Service
@@ -40,6 +42,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtTokenDomainService jwtTokenDomainService;
     private final S3Uploader s3Uploader;
+    private List<AddCatRequest> cats;
 
     @Override
     public SocialLoginResultResponse registerNewMember(ExtraSignupRequest request, MultipartFile profileImage) {
@@ -78,7 +81,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         if (!NicknameValidator.isPatternValid(nickname)) {
             throw new BusinessException(ErrorCode.INVALID_NICKNAME_FORMAT);
         }
-        if (memberRepository.existsByNicknameAndDeletedAtIsNull(nickname)) {
+        if (memberRepository.existsByNickname(nickname)) {
             throw new BusinessException(ErrorCode.USING_NICKNAME);
         }
 

--- a/src/main/java/com/sixmycat/catchy/feature/member/command/domain/repository/MemberRepository.java
+++ b/src/main/java/com/sixmycat/catchy/feature/member/command/domain/repository/MemberRepository.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-   boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 
     @Query("SELECT m.profileImage FROM Member m WHERE m.id = :id AND m.deletedAt IS NULL")
     Optional<String> findProfileImageByIdAndDeletedAtIsNull(@Param("id") Long id);
@@ -21,4 +20,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findById(Long id);
 
     Optional<Member> findByEmailAndSocialAndDeletedAtIsNull(String email, String upperCase);
+
+    boolean existsByNickname(String nickname);
 }


### PR DESCRIPTION
### 🛰️ Issue
탈퇴한 유저의 닉네임 재사용 불가

### 🪐 작업 내용
유저가 탈퇴해도 게시물이 계속 보이기 때문에 탈퇴한 회원의 닉네임도 재사용이 불가능 하도록 하였습니다.

### 📚 논의하고싶은 내용 (선택)


### ✅ Check List (선택)
- [ ] 
- [ ]